### PR TITLE
chore: use interface for FS instead of embed.FS; Update pkg to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This package loads config information into a struct. It uses [viper](https://git
 ## Installation
 
 ```sh
-go get github.com/nrfta/go-config/v2
+go get github.com/nrfta/go-config/v3
 ```
 
 ## Usage
@@ -36,7 +36,7 @@ In the file you want to load the config in do the following:
 import (
     "embed"
 
-	"github.com/nrfta/go-config/v2"
+	"github.com/nrfta/go-config/v3"
 )
 
 // this MyAppConfig struct is the "custom struct" it has the same attributes that mirror the config json above

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"embed"
 	"errors"
 	"fmt"
 	"os"
@@ -18,8 +17,12 @@ type MetaConfig struct {
 	ServiceName string `mapstructure:"service_name"`
 }
 
+type fileSystem interface {
+	ReadFile(name string) ([]byte, error)
+}
+
 // Load config from file then from environment variables
-func Load(fs embed.FS, config interface{}) error {
+func Load(fs fileSystem, config interface{}) error {
 	configType := "json"
 	viper.SetConfigType(configType)
 

--- a/config_test.go
+++ b/config_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/nrfta/go-config/v2"
+	"github.com/nrfta/go-config/v3"
 )
 
 //go:embed config_test.json

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nrfta/go-config/v2
+module github.com/nrfta/go-config/v3
 
 go 1.21
 


### PR DESCRIPTION

## Description / Changes

Updated to use an interface instead of embed.FS, this allows the pkg to be used in other applications. 
Update to pkg name to v3 due to project in gihub having a release version v2 already.



## How did you test the changes?

tests

## Dependencies

None
