### PR TITLE
chore: add read json func

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"strings"
@@ -39,8 +40,15 @@ func Load(fs fileSystem, config interface{}) error {
 		return fmt.Errorf("unable to read config from %s: %w", configFile, err)
 	}
 
-	if err := viper.ReadConfig(bytes.NewReader(contents)); err != nil {
-		return fmt.Errorf("unable to read config from %s: %w", configFile, err)
+	return ReadJSON(bytes.NewReader(contents), config)
+}
+
+func ReadJSON(in io.Reader, config interface{}) error {
+	configType := "json"
+	viper.SetConfigType(configType)
+
+	if err := viper.ReadConfig(in); err != nil {
+		return fmt.Errorf("unable to read config: %v", err)
 	}
 
 	return unmarshalConfig(config)


### PR DESCRIPTION
## Description

The main `Load` func uses an internal `isTesting` func to determine the config file to use, however, that check func does not always work. The `ReadJSON` will load a json config from the provided reader to allow for explicit loading of a config file.

## How did you test the changes?

- Locally

## Dependencies

N/A
