### PR TITLE
bug: more reliably find out if running in tests

### DIFF
--- a/config.go
+++ b/config.go
@@ -88,11 +88,12 @@ func unmarshalConfig(config interface{}) error {
 
 func isTesting() bool {
 	for _, arg := range os.Args {
-		if strings.HasPrefix(arg, "-test.v=") {
+		if strings.Contains(arg, "-test") || strings.Contains(arg, ".test") {
 			return true
 		}
 	}
-	return false || os.Getenv("ENV") == "test"
+
+	return os.Getenv("ENV") == "test"
 }
 
 func getMetaConfig(config interface{}) *MetaConfig {


### PR DESCRIPTION
## Linear Ticket Link



## Description

Previously, we could be running tests, but the previous implementation did not pick that up. 

## How did you test the changes?

Ran the code locally

## Dependencies

None